### PR TITLE
feat: change bet tiers from [10K,50K,100K,500K] to [2K,10K,50K,100K]

### DIFF
--- a/packages/foundry/contracts/TenTwentyFourX.sol
+++ b/packages/foundry/contracts/TenTwentyFourX.sol
@@ -14,7 +14,7 @@ import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
  * to cover any single winning bet. Disclaimer covers simultaneous wins.
  *
  * Economics:
- * - Bet tiers: 10K / 50K / 100K / 500K CLAWD
+ * - Bet tiers: 2K / 10K / 50K / 100K CLAWD
  * - Multipliers: 2x to 1024x (powers of 2)
  * - 1% of every bet burned forever
  * - 2% house edge on winnings
@@ -34,10 +34,10 @@ contract TenTwentyFourX is ReentrancyGuard {
     uint256 public constant MAX_PAYOUT_DIVISOR = 5; // Max payout = house balance / 5
 
     uint256[4] public VALID_BETS = [
+        2_000 * 1e18,
         10_000 * 1e18,
         50_000 * 1e18,
-        100_000 * 1e18,
-        500_000 * 1e18
+        100_000 * 1e18
     ];
 
     uint256[10] public VALID_MULTIPLIERS = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];

--- a/packages/foundry/test/TenTwentyFourX.t.sol
+++ b/packages/foundry/test/TenTwentyFourX.t.sol
@@ -17,9 +17,9 @@ contract TenTwentyFourXTest is Test {
     address public player = address(0x1);
     address public gameOwner = address(0x99);
 
+    uint256 constant BET_2K = 2_000 * 1e18;
     uint256 constant BET_10K = 10_000 * 1e18;
     uint256 constant BET_50K = 50_000 * 1e18;
-    uint256 constant BET_500K = 500_000 * 1e18;
 
     function setUp() public {
         token = new MockCLAWD();
@@ -132,12 +132,12 @@ contract TenTwentyFourXTest is Test {
         address burnAddr = 0x000000000000000000000000000000000000dEaD;
         uint256 burnBefore = token.balanceOf(burnAddr);
         vm.startPrank(player);
-        token.approve(address(game), BET_500K);
+        token.approve(address(game), BET_50K);
         bytes32 hash = game.computeHash(bytes32(uint256(42)), bytes32(uint256(1)));
-        game.click(hash, BET_500K, 2);
+        game.click(hash, BET_50K, 2);
         vm.stopPrank();
-        assertEq(token.balanceOf(burnAddr) - burnBefore, 5_000 * 1e18);
-        assertEq(game.totalBurned(), 5_000 * 1e18);
+        assertEq(token.balanceOf(burnAddr) - burnBefore, 500 * 1e18);
+        assertEq(game.totalBurned(), 500 * 1e18);
     }
 
     function testInvalidBet() public {
@@ -228,7 +228,7 @@ contract TenTwentyFourXTest is Test {
 
     function testPayoutCalculation() public view {
         assertEq(game.getPayoutFor(BET_10K, 2), 19_600 * 1e18);
-        assertEq(game.getPayoutFor(BET_500K, 1024), 501_760_000 * 1e18);
+        assertEq(game.getPayoutFor(BET_2K, 1024), 2_007_040 * 1e18);
     }
 
     function testTwoStepOwnership() public {

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -84,10 +84,10 @@ function RollingAnimation({ multiplier }: { multiplier: number }) {
 }
 
 const BET_TIERS = [
+  { value: parseEther("2000"), label: "2K", display: "2,000" },
   { value: parseEther("10000"), label: "10K", display: "10,000" },
   { value: parseEther("50000"), label: "50K", display: "50,000" },
   { value: parseEther("100000"), label: "100K", display: "100,000" },
-  { value: parseEther("500000"), label: "500K", display: "500,000" },
 ];
 
 const MULTIPLIERS = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];


### PR DESCRIPTION
## Summary

Lowers the minimum bet tier and removes the highest tier for broader accessibility.

### Changes
- **Contract**: VALID_BETS array → `[2K, 10K, 50K, 100K]` (was `[10K, 50K, 100K, 500K]`)
- **Frontend**: BET_TIERS array updated to match
- **Tests**: Replaced 500K references with valid tiers, updated payout/burn assertions
- **Comment**: Updated bet tier documentation in contract header

### New tiers
| Old | New |
|-----|-----|
| 10K | 2K |
| 50K | 10K |
| 100K | 50K |
| 500K | 100K |